### PR TITLE
분리된 CSS와 스크립트 파일 추가

### DIFF
--- a/codexTest.html
+++ b/codexTest.html
@@ -6,89 +6,8 @@
     <title>본 개인화 주요 개발 구성 및 기능 요소</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <style>
-        body {
-            font-family: 'Noto Sans KR', sans-serif;
-            background-color: #f8f9fa;
-            color: #333;
-            padding: 2rem;
-        }
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-        }
-        h1 {
-            font-weight: 700;
-            border-bottom: 2px solid #3c6382;
-            padding-bottom: 0.5rem;
-            margin-bottom: 2rem;
-        }
-        .feature-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 1.5rem;
-        }
-        .feature-card {
-            background-color: white;
-            border-radius: 8px;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-            padding: 1.5rem;
-            height: 100%;
-            transition: transform 0.2s, box-shadow 0.2s;
-            border-top: 4px solid;
-        }
-        .feature-card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
-        }
-        .card-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            margin-bottom: 1rem;
-            border-bottom: 1px solid #e0e0e0;
-            padding-bottom: 0.5rem;
-        }
-        .card-content {
-            font-size: 0.95rem;
-        }
-        .card-content ul {
-            padding-left: 1.5rem;
-            list-style-type: none;
-        }
-        .card-content li {
-            margin-bottom: 0.75rem;
-            position: relative;
-        }
-        .card-content li:before {
-            content: "•";
-            color: #3c6382;
-            font-weight: bold;
-            position: absolute;
-            left: -1rem;
-        }
-        .bottom-grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 1.5rem;
-            margin-top: 1.5rem;
-        }
-        .raman-spectrum {
-            border-top-color: #1e3799;
-        }
-        .ai-algorithm {
-            border-top-color: #38ada9;
-        }
-        .analysis-tools {
-            border-top-color: #b71540;
-        }
-        .prediction-analysis {
-            border-top-color: #fa983a;
-        }
-        .platform-integration {
-            border-top-color: #6a89cc;
-        }
-    </style>
+    <link rel="stylesheet" href="style.css">
+    
 </head>
 <body>
     <div class="container">
@@ -170,5 +89,6 @@
             <p>© 2023 라만 스펙트럼 기반 개인화 시스템</p>
         </footer>
     </div>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const cards = document.querySelectorAll('.feature-card');
+    cards.forEach(card => {
+        card.addEventListener('click', () => {
+            card.classList.toggle('active');
+        });
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,101 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Apple SD Gothic Neo',
+        'Malgun Gothic', 'Nanum Gothic', Arial, sans-serif;
+    background-color: #f8f9fa;
+    color: #333;
+    padding: 2rem;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+h1 {
+    font-weight: 700;
+    border-bottom: 2px solid #3c6382;
+    padding-bottom: 0.5rem;
+    margin-bottom: 2rem;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+}
+
+.feature-card {
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    padding: 1.5rem;
+    height: 100%;
+    transition: transform 0.2s, box-shadow 0.2s;
+    border-top: 4px solid;
+}
+
+.feature-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
+}
+
+.card-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 0.5rem;
+}
+
+.card-content {
+    font-size: 0.95rem;
+}
+
+.card-content ul {
+    padding-left: 1.5rem;
+    list-style-type: none;
+}
+
+.card-content li {
+    margin-bottom: 0.75rem;
+    position: relative;
+}
+
+.card-content li:before {
+    content: "\2022";
+    color: #3c6382;
+    font-weight: bold;
+    position: absolute;
+    left: -1rem;
+}
+
+.bottom-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.raman-spectrum {
+    border-top-color: #1e3799;
+}
+
+.ai-algorithm {
+    border-top-color: #38ada9;
+}
+
+.analysis-tools {
+    border-top-color: #b71540;
+}
+
+.prediction-analysis {
+    border-top-color: #fa983a;
+}
+
+.platform-integration {
+    border-top-color: #6a89cc;
+}
+
+.feature-card.active {
+    background-color: #f0f8ff;
+}


### PR DESCRIPTION
## 요약
- HTML 내부 스타일을 `style.css` 로 분리
- 간단한 카드 클릭 이벤트를 `script.js` 로 구현
- 변경된 링크를 통해 외부 CSS/JS 로드
- Noto Sans KR 대신 범용적인 시스템 폰트 스택 사용

## 테스트
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6836ad8a1ca083209013c0a947a8ce88